### PR TITLE
Added the ability to modify message categories, disable messages

### DIFF
--- a/example/simple_app.py
+++ b/example/simple_app.py
@@ -1,6 +1,6 @@
 from flask import Flask, jsonify, render_template
 from flask.views import MethodView
-from flask_simplelogin import SimpleLogin, get_username, login_required
+from flask_simplelogin import SimpleLogin, get_username, login_required, Message
 
 my_users = {
     'chuck': {'password': 'norris', 'roles': ['admin']},
@@ -27,8 +27,19 @@ def check_my_users(user):
 app = Flask(__name__)
 app.config.from_object('settings')
 
-SimpleLogin(app, login_checker=check_my_users)
+messages = {
+    'login_success': Message('login success!', category='success'),
+    'login_failure': Message('invalid credentials', category='danger'),
+    'is_logged_in': Message('already logged in'),
+    'logout': Message('Logged out!'),
+    'login_required': Message('You need to login first', category='warning'),
+    'access_denied': Message('Access Denied'),
+    'auth_error': Message('Authentication Error: {0}')
+}
 
+#I'm not sure what the appropriate naming convention is here.
+simple_login = SimpleLogin(app, login_checker=check_my_users, messages=messages)
+simple_login.disable_messages('login_success','logout')
 
 @app.route('/')
 def index():

--- a/example/simple_app.py
+++ b/example/simple_app.py
@@ -1,5 +1,10 @@
 from flask import Flask, jsonify, render_template
 from flask.views import MethodView
+
+from collections import namedtuple
+
+import sys
+sys.path.append(".")
 from flask_simplelogin import SimpleLogin, get_username, login_required
 
 my_users = {
@@ -8,7 +13,16 @@ my_users = {
     'mary': {'password': 'jane', 'roles': []},
     'steven': {'password': 'wilson', 'roles': ['admin']}
 }
-
+Message=namedtuple("Message", "message category")
+messages = {
+    'login_success': Message('login success!', 'danger'),
+    'login_failure': Message('invalid credentials','success'),
+    'is_logged_in': Message('already logged in','primary'),
+    'logout': Message('Logged out!','primary'),
+    'login_required': Message('You need to login first','success'),
+    'access_denied': 'Access Denied',
+    'auth_error': 'Authentication Error: {0}',
+}
 
 def check_my_users(user):
     """Check if user exists and its credentials.
@@ -27,8 +41,7 @@ def check_my_users(user):
 app = Flask(__name__)
 app.config.from_object('settings')
 
-SimpleLogin(app, login_checker=check_my_users)
-
+SimpleLogin(app, login_checker=check_my_users, messages=messages)
 
 @app.route('/')
 def index():

--- a/example/simple_app.py
+++ b/example/simple_app.py
@@ -1,10 +1,5 @@
 from flask import Flask, jsonify, render_template
 from flask.views import MethodView
-
-from collections import namedtuple
-
-import sys
-sys.path.append(".")
 from flask_simplelogin import SimpleLogin, get_username, login_required
 
 my_users = {
@@ -13,16 +8,7 @@ my_users = {
     'mary': {'password': 'jane', 'roles': []},
     'steven': {'password': 'wilson', 'roles': ['admin']}
 }
-Message=namedtuple("Message", "message category")
-messages = {
-    'login_success': Message('login success!', 'danger'),
-    'login_failure': Message('invalid credentials','success'),
-    'is_logged_in': Message('already logged in','primary'),
-    'logout': Message('Logged out!','primary'),
-    'login_required': Message('You need to login first','success'),
-    'access_denied': 'Access Denied',
-    'auth_error': 'Authentication Error: {0}',
-}
+
 
 def check_my_users(user):
     """Check if user exists and its credentials.
@@ -41,7 +27,8 @@ def check_my_users(user):
 app = Flask(__name__)
 app.config.from_object('settings')
 
-SimpleLogin(app, login_checker=check_my_users, messages=messages)
+SimpleLogin(app, login_checker=check_my_users)
+
 
 @app.route('/')
 def index():

--- a/flask_simplelogin/__init__.py
+++ b/flask_simplelogin/__init__.py
@@ -90,7 +90,7 @@ def login_required(function=None, username=None, basic=False, must=None):
         for validator in validators:
             error = validator(get_username())
             if error is not None:
-                return SimpleLogin.get_message('auth_error', error).text, 403
+                return SimpleLogin.get_message('auth_error', error).return_message(), 403
 
     def dispatch(fun, *args, **kwargs):
         if basic and request.is_json:
@@ -99,7 +99,7 @@ def login_required(function=None, username=None, basic=False, must=None):
         if is_logged_in(username=username):
             return check(must) or fun(*args, **kwargs)
         elif is_logged_in():
-            return SimpleLogin.get_message('access_denied').text, 403
+            return SimpleLogin.get_message('access_denied').return_message(), 403
         else:
             SimpleLogin.get_message('login_required').flash()
             return redirect(url_for('simplelogin.login', next=request.path))
@@ -137,7 +137,10 @@ class Message():
     def flash(self):
         if self.text and self.enabled:
             flash(self.text, self.category)
-
+    
+    def return_message(self):
+        if self.text and self.enabled:
+            return self.text
 
 class SimpleLogin(object):
     """Simple Flask Login"""
@@ -157,9 +160,6 @@ class SimpleLogin(object):
         """Helper to get internal messages outside this instance"""
         msg = current_app.extensions['simplelogin'].messages.get(
             message)
-        
-        if not msg.enabled or not message.text:
-            return
         
         if args or kwargs:
             msg.text.format(*args, **kwargs)

--- a/flask_simplelogin/__init__.py
+++ b/flask_simplelogin/__init__.py
@@ -157,12 +157,14 @@ class SimpleLogin(object):
         """Helper to get internal messages outside this instance"""
         msg = current_app.extensions['simplelogin'].messages.get(
             message)
-        if msg.enabled:
-            if msg.text and (args or kwargs):
-                return msg.text.format(*args, **kwargs)
-            return msg.text
-        return
-
+        if not msg.enabled or not message.text:
+            return
+        
+        if args or kwargs:
+            return msg.text.format(*args, **kwargs)
+            
+        return msg.text
+        
     def __init__(self, app=None, login_checker=None,
                  login_form=None, messages=None):
         self.config = {

--- a/flask_simplelogin/__init__.py
+++ b/flask_simplelogin/__init__.py
@@ -142,7 +142,7 @@ class SimpleLogin(object):
         'logout': Message('Logged out!','primary'),
         'login_required': Message('You need to login first','warning'),
         'access_denied': 'Access Denied',
-        'auth_error': 'Authentication Error: {0}',
+        'auth_error': 'Authentication Error: {0}'
     }
 
     @staticmethod

--- a/flask_simplelogin/__init__.py
+++ b/flask_simplelogin/__init__.py
@@ -101,8 +101,7 @@ def login_required(function=None, username=None, basic=False, must=None):
         elif is_logged_in():
             return SimpleLogin.get_message('access_denied'), 403
         else:
-            message = SimpleLogin.get_message('login_required')
-            message.flash()
+            SimpleLogin.get_message('login_required').flash()
             return redirect(url_for('simplelogin.login', next=request.path))
 
     def dispatch_basic_auth(fun, *args, **kwargs):
@@ -146,8 +145,8 @@ class SimpleLogin(object):
     messages = {
         'login_success': Message('login success!', category='success'),
         'login_failure': Message('invalid credentials', category='danger'),
-        'is_logged_in': Message('already logged in', category='primary'),
-        'logout': Message('Logged out!', category='primary'),
+        'is_logged_in': Message('already logged in'),
+        'logout': Message('Logged out!'),
         'login_required': Message('You need to login first', category='warning'),
         'access_denied': Message('Access Denied'),
         'auth_error': Message('Authentication Error: {0}')
@@ -311,8 +310,7 @@ class SimpleLogin(object):
         )
 
         if is_logged_in():
-            message = self.messages['is_logged_in']
-            message.flash()
+            self.messages['is_logged_in'].flash()
             return redirect(destiny)
 
         if request.is_json:
@@ -323,19 +321,16 @@ class SimpleLogin(object):
         ret_code = 200
         if form.validate_on_submit():
             if self._login_checker(form.data):
-                message = self.messages['login_success']
-                message.flash()
+                self.messages['login_success'].flash()
                 session['simple_logged_in'] = True
                 session['simple_username'] = form.data.get('username')
                 return redirect(destiny)
             else:
-                message = self.messages['login_failure']
-                message.flash()
+                self.messages['login_failure'].flash()
                 ret_code = 401  # <-- invalid credentials RFC7235
         return render_template('login.html', form=form, next=destiny), ret_code
 
     def logout(self):
         session.clear()
-        message = self.messages['logout']
-        message.flash()
+        self.messages['logout'].flash()
         return redirect(self.config.get('home_url', '/'))

--- a/flask_simplelogin/__init__.py
+++ b/flask_simplelogin/__init__.py
@@ -163,7 +163,6 @@ class SimpleLogin(object):
         
         if args or kwargs:
             msg.text.format(*args, **kwargs)
-            return msg
 
         return msg
         

--- a/flask_simplelogin/__init__.py
+++ b/flask_simplelogin/__init__.py
@@ -162,7 +162,7 @@ class SimpleLogin(object):
         
         if args or kwargs:
             return msg.text.format(*args, **kwargs)
-            
+
         return msg.text
         
     def __init__(self, app=None, login_checker=None,
@@ -204,8 +204,6 @@ class SimpleLogin(object):
         # If the user is disabling messages
         # Must differentiate between None and False.
         elif messages is False:
-            
-            # I almost put this in a dict comprehension, but I couldn't figure out how to update value.enabled
             disabled_messages={}
             for key, value in self.messages.items():
                 value.enabled=False

--- a/flask_simplelogin/__init__.py
+++ b/flask_simplelogin/__init__.py
@@ -90,7 +90,7 @@ def login_required(function=None, username=None, basic=False, must=None):
         for validator in validators:
             error = validator(get_username())
             if error is not None:
-                return SimpleLogin.get_message('auth_error', error), 403
+                return SimpleLogin.get_message('auth_error', error).text, 403
 
     def dispatch(fun, *args, **kwargs):
         if basic and request.is_json:
@@ -99,7 +99,7 @@ def login_required(function=None, username=None, basic=False, must=None):
         if is_logged_in(username=username):
             return check(must) or fun(*args, **kwargs)
         elif is_logged_in():
-            return SimpleLogin.get_message('access_denied'), 403
+            return SimpleLogin.get_message('access_denied').text, 403
         else:
             SimpleLogin.get_message('login_required').flash()
             return redirect(url_for('simplelogin.login', next=request.path))
@@ -157,13 +157,15 @@ class SimpleLogin(object):
         """Helper to get internal messages outside this instance"""
         msg = current_app.extensions['simplelogin'].messages.get(
             message)
+        
         if not msg.enabled or not message.text:
             return
         
         if args or kwargs:
-            return msg.text.format(*args, **kwargs)
+            msg.text.format(*args, **kwargs)
+            return msg
 
-        return msg.text
+        return msg
         
     def __init__(self, app=None, login_checker=None,
                  login_form=None, messages=None):

--- a/flask_simplelogin/__init__.py
+++ b/flask_simplelogin/__init__.py
@@ -129,20 +129,24 @@ def login_required(function=None, username=None, basic=False, must=None):
         return wrap
     return decorator
 
-
+class Message():
+    def __init__(self, message, category="primary", enabled=True):
+        self.message=message
+        self.category=category
+    def flash(self):
+        if self.message:
+            flash(self.message, self.category)
 class SimpleLogin(object):
     """Simple Flask Login"""
 
-    Message = namedtuple("Message", "message category")
-
     messages = {
-        'login_success': Message('login success!', 'success'),
-        'login_failure': Message('invalid credentials', 'danger'),
-        'is_logged_in': Message('already logged in', 'primary'),
-        'logout': Message('Logged out!', 'primary'),
-        'login_required': Message('You need to login first', 'warning'),
-        'access_denied': 'Access Denied',
-        'auth_error': 'Authentication Error: {0}'
+        'login_success': Message('login success!', category='success'),
+        'login_failure': Message('invalid credentials', category='danger'),
+        'is_logged_in': Message('already logged in', category='primary'),
+        'logout': Message('Logged out!', category='primary'),
+        'login_required': Message('You need to login first', category='warning'),
+        'access_denied': Message('Access Denied'),
+        'auth_error': Message('Authentication Error: {0}')
     }
 
     @staticmethod

--- a/flask_simplelogin/__init__.py
+++ b/flask_simplelogin/__init__.py
@@ -167,6 +167,10 @@ class SimpleLogin(object):
 
         return msg
 
+    def disable_messages(self, *args, **kwargs):
+        for i in args:
+            self.messages[i].enabled=False
+
     def __init__(self, app=None, login_checker=None,
                  login_form=None, messages=None):
         self.config = {

--- a/flask_simplelogin/__init__.py
+++ b/flask_simplelogin/__init__.py
@@ -133,14 +133,14 @@ def login_required(function=None, username=None, basic=False, must=None):
 class SimpleLogin(object):
     """Simple Flask Login"""
 
-    Message=namedtuple("Message", "message category")
+    Message = namedtuple("Message", "message category")
 
     messages = {
         'login_success': Message('login success!', 'success'),
-        'login_failure': Message('invalid credentials','danger'),
-        'is_logged_in': Message('already logged in','primary'),
-        'logout': Message('Logged out!','primary'),
-        'login_required': Message('You need to login first','warning'),
+        'login_failure': Message('invalid credentials', 'danger'),
+        'is_logged_in': Message('already logged in', 'primary'),
+        'logout': Message('Logged out!', 'primary'),
+        'login_required': Message('You need to login first', 'warning'),
         'access_denied': 'Access Denied',
         'auth_error': 'Authentication Error: {0}'
     }
@@ -185,14 +185,14 @@ class SimpleLogin(object):
 
         if login_form:
             self._login_form = login_form
-        
-        # If the user is passing a new dictionary 
+
+        # If the user is passing a new dictionary
         if messages and isinstance(messages, dict):
             self.messages.update(messages)
         # If the user is disabling messages
-        # Must differentiate between None and False. 
+        # Must differentiate between None and False.
         elif messages is False:
-            self.messages=False
+            self.messages = False
         self._register(app)
         self._load_config()
         self._set_default_secret()
@@ -211,10 +211,10 @@ class SimpleLogin(object):
 
     def _load_config(self):
         config = self.app.config.get_namespace(
-                namespace='SIMPLELOGIN_',
-                lowercase=True,
-                trim_namespace=True
-            )
+            namespace='SIMPLELOGIN_',
+            lowercase=True,
+            trim_namespace=True
+        )
 
         # backwards compatibility
         old_config = self.app.config.get_namespace(

--- a/flask_simplelogin/__init__.py
+++ b/flask_simplelogin/__init__.py
@@ -137,10 +137,11 @@ class Message():
     def flash(self):
         if self.text and self.enabled:
             flash(self.text, self.category)
-    
+
     def return_message(self):
         if self.text and self.enabled:
             return self.text
+
 
 class SimpleLogin(object):
     """Simple Flask Login"""
@@ -160,12 +161,12 @@ class SimpleLogin(object):
         """Helper to get internal messages outside this instance"""
         msg = current_app.extensions['simplelogin'].messages.get(
             message)
-        
+
         if args or kwargs:
             msg.text.format(*args, **kwargs)
 
         return msg
-        
+
     def __init__(self, app=None, login_checker=None,
                  login_form=None, messages=None):
         self.config = {
@@ -205,10 +206,10 @@ class SimpleLogin(object):
         # If the user is disabling messages
         # Must differentiate between None and False.
         elif messages is False:
-            disabled_messages={}
+            disabled_messages = {}
             for key, value in self.messages.items():
-                value.enabled=False
-                disabled_messages[key]=value
+                value.enabled = False
+                disabled_messages[key] = value
             self.messages.update(disabled_messages)
         self._register(app)
         self._load_config()

--- a/flask_simplelogin/__init__.py
+++ b/flask_simplelogin/__init__.py
@@ -129,10 +129,10 @@ def login_required(function=None, username=None, basic=False, must=None):
 
 
 class Message():
-    def __init__(self, text, category="primary", enabled=True):
+    def __init__(self, text="", category="primary", enabled=True):
         self.text = text
         self.category = category
-        self.enabled = True
+        self.enabled = enabled
 
     def flash(self):
         if self.text and self.enabled:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -32,6 +32,10 @@ def test_post_with_token(client):
     assert 'csrf_token The CSRF token is missing' not in str(response.data)
     # token is still invalid :(
 
+def test_no_message_customization(client):
+    response = client.get('/secret', follow_redirects = True)
+    assert response.status_code == 200
+    assert b'You need to login first' in response.data
 
 # def test_is_logged_in(client):
 #     session.clear()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -33,7 +33,7 @@ def test_post_with_token(client):
     # token is still invalid :(
 
 def test_no_message_customization(client):
-    response = client.get('/secret', follow_redirects = True)
+    response = client.get('/secret', follow_redirects=True)
     assert response.status_code == 200
     assert b'You need to login first' in response.data
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 import pytest
 from flask import Flask
-from flask_simplelogin import SimpleLogin
+from flask_simplelogin import SimpleLogin, Message
 
 
 class Settings(dict):
@@ -56,3 +56,25 @@ def test_configs_are_loaded_with_backwards_compatibility(client):
     assert sl.config['login_url'] == '/custom_login/'
     assert sl.config['logout_url'] == '/custom_logout/'
     assert sl.config['home_url'] == '/custom_home/'
+
+def test_messages_disabled(app):
+    app = Flask(__name__)
+    app.config['SECRET_KEY'] = 'secret-here'
+    sl = SimpleLogin(app, messages=False)
+    for message in sl.messages.values():
+        assert not message.enabled
+
+def test_messages_customized(app):
+    app = Flask(__name__)
+    app.config['SECRET_KEY'] = 'secret-here'
+    custom_message_dict = {
+        'login_success': Message('login_success_custom_message', category='login_success_custom_category'),
+        'logout':Message(enabled=False)
+    }
+    sl = SimpleLogin(app, messages=custom_message_dict)
+    # Assert that custom messages and categories have been changed.
+    assert custom_message_dict['login_success'].text == sl.messages['login_success'].text
+    assert custom_message_dict['login_success'].category == sl.messages['login_success'].category
+    assert not sl.messages['logout'].enabled
+    # Assert that keys not specified remain the same. 
+    assert sl.messages['login_required'].text=='You need to login first'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -69,7 +69,7 @@ def test_messages_customized(app):
     app.config['SECRET_KEY'] = 'secret-here'
     custom_message_dict = {
         'login_success': Message('login_success_custom_message', category='login_success_custom_category'),
-        'logout':Message(enabled=False)
+        'logout': Message(enabled=False)
     }
     sl = SimpleLogin(app, messages=custom_message_dict)
     # Assert that custom messages and categories have been changed.


### PR DESCRIPTION
Like the title suggests, this PR would allow users to set custom message categories and disable the messages from flask_simplelogin entirely. (See issue #17)
This is done by replacing the string values in the messages dictionary with namedtuples (as recommended by @cuducos). The first value is the message string, the second is the category for flask to flash it as. 

This allows for some, interesting, modifications (as well as more practical ones if you use different categories in your project):
![Annotation 2019-10-25 181834](https://user-images.githubusercontent.com/51516525/67611220-4f866780-f755-11e9-9135-6c991ac1f8a3.png)
![Annotation 2019-10-25 181759](https://user-images.githubusercontent.com/51516525/67611221-51e8c180-f755-11e9-913c-3fce315914b3.png)

If the user sets `messages=False` flask_simplelogin will not flash any messages. 

There are still some issues that need to be worked on though:

- As far as I can tell, the user needs to set up the namedtuple themselves 
     ```
     from collections import namedtuple
     Message = namedtuple("Message","message category")
     ```
     for their app to use a custom dict. I wonder if there's a simple way...
- There's no way to disable messages individually, which could be useful if you use a custom login checker, but want to keep other messages.
- `'access_denied'` and `'auth_error'` don't currently use the namedtuple, which is somewhat unintuitive, but they don't have categories. 
- I'd like a second opinion on lines 183-184 (master) vs. 190-195 (message-improvements). The logic seems sound, but it feels like there should be a more pythonic way of doing it. 
- I haven't updated the README to reflect any of these changes yet. 

